### PR TITLE
feat: publish versioned image tags to dockerhub

### DIFF
--- a/.github/workflows/scip-release.yml
+++ b/.github/workflows/scip-release.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           file: Dockerfile.autoindex
           push: true
-          tags: sourcegraph/scip-python:autoindex
+          tags: sourcegraph/scip-python:autoindex,sourcegraph/scip-python:${{ github.ref_name }}


### PR DESCRIPTION
Great to see this replace the dormant lsif-py!

Currently I see only `autoindex` tags are published on dockerhub, which makes it hard to pin images when using renovate/dependabot etc. This PR should publish the current tag as well. /cc @macraig

https://github.com/docker/build-push-action#inputs
https://stackoverflow.com/a/69919067
https://docs.github.com/en/actions/learn-github-actions/contexts

Edit: oh I'm silly, see https://github.com/sourcegraph/scip-python/pull/52 instead.